### PR TITLE
Fix KeyAnchor and KeyCrystal

### DIFF
--- a/src/main/java/com/volt/module/ModuleManager.java
+++ b/src/main/java/com/volt/module/ModuleManager.java
@@ -52,9 +52,9 @@ public final class ModuleManager {
         add(
                 new AutoMace(), new TotemHit(), new TriggerBot(), new Velocity(),
                 new ShieldBreaker(), new ThrowPot(), new ElytraHotSwap(),
-                new AntiMiss(), new WTap(), new STap(),     
-                new AimAssist(), new SwordHotSwap(), new AutoCrystal(), new SwordSwap()
-        );
+                new AntiMiss(), new WTap(), new STap(),
+                new AimAssist(), new SwordHotSwap(), new AutoCrystal(), new KeyCrystal(), new KeyAnchor(),
+                new SwordSwap());
         // Movement
         add(new Sprint(), new AutoFirework(), new AutoHeadHitter());
 
@@ -63,21 +63,18 @@ public final class ModuleManager {
                 new AutoExtinguish(), new AutoTool(), new AutoWeb(), new AutoRefill(),
                 new AutoDrain(), new AutoCrafter(), new FastPlace(), new FastEXP(),
                 new Eagle(), new TrapSave(), new PingSpoof(), new AutoDoubleHand(),
-                new FastMine()
-        );
+                new FastMine());
 
         // Render
         add(
                 new ContainerSlots(), new FullBright(), new HUD(), new PlayerESP(),
                 new SwingSpeed(), new OreESP(), new Trajectory(), new FpsCounter(),
-                new SkeletonESP(), new EntityESP()
-        );
+                new SkeletonESP(), new EntityESP());
 
         // Misc
         add(
                 new CartKey(), new HoverTotem(), new MiddleClickFriend(),
-                new PearlKey(), new WindChargeKey(), new Teams(), new FakePlayer()
-        );
+                new PearlKey(), new WindChargeKey(), new Teams(), new FakePlayer());
 
         // Client
         add(new ClickGUIModule(), new Client(), new Panic(), new Debugger());

--- a/src/main/java/com/volt/module/modules/combat/KeyAnchor.java
+++ b/src/main/java/com/volt/module/modules/combat/KeyAnchor.java
@@ -1,0 +1,226 @@
+package com.volt.module.modules.combat;
+
+import com.volt.event.impl.player.TickEvent;
+import com.volt.mixin.MinecraftClientAccessor;
+import com.volt.module.Category;
+import com.volt.module.Module;
+import com.volt.module.setting.BooleanSetting;
+import com.volt.module.setting.KeybindSetting;
+import com.volt.module.setting.NumberSetting;
+import com.volt.utils.keybinding.KeyUtils;
+import com.volt.utils.math.TimerUtil;
+import com.volt.utils.mc.MouseSimulation;
+
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.RespawnAnchorBlock;
+import net.minecraft.item.Items;
+import net.minecraft.item.SwordItem;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import org.lwjgl.glfw.GLFW;
+
+public final class KeyAnchor extends Module {
+
+    private final KeybindSetting anchorKeybind = new KeybindSetting("Anchor Key", GLFW.GLFW_KEY_X, false);
+    private final NumberSetting delay = new NumberSetting("Delay (MS)", 1, 500, 50, 1);
+    private final NumberSetting restoreDelayTicks = new NumberSetting("Restore Delay", 1, 20, 2, 1);
+    private final BooleanSetting mouseSimulation = new BooleanSetting("Mouse Simulation", true);
+
+    private final TimerUtil timer = new TimerUtil();
+    private boolean keyPressed = false;
+    private boolean isActive = false;
+    private int originalSlot = -1;
+    private boolean hasPlacedThisCycle = false;
+    private boolean pendingRestoreSlot = false;
+    private int pendingRestoreTicksLeft = 0;
+
+    public KeyAnchor() {
+        super("Key Anchor", "Automatically places and explodes respawn anchors for PvP", -1, Category.COMBAT);
+        this.addSettings(anchorKeybind, delay, restoreDelayTicks, mouseSimulation);
+        this.getSettings().removeIf(setting -> setting instanceof KeybindSetting && !setting.equals(anchorKeybind));
+    }
+
+    @EventHandler
+    private void onTickEvent(TickEvent event) {
+        if (isNull() || !isEnabled())
+            return;
+        if (mc.currentScreen != null)
+            return;
+        boolean currentKeyState = KeyUtils.isKeyPressed(anchorKeybind.getKeyCode());
+
+        if (currentKeyState && !keyPressed) {
+            startAnchorPvP();
+        } else if (!currentKeyState && keyPressed) {
+            stopAnchorPvP();
+        } else if (!currentKeyState) {
+            hasPlacedThisCycle = false;
+        }
+
+        keyPressed = currentKeyState;
+
+        if (isActive && timer.hasElapsedTime(delay.getValueInt())) {
+            processAnchorPvP();
+            timer.reset();
+        }
+
+        if (pendingRestoreSlot) {
+            if (pendingRestoreTicksLeft <= 0) {
+                restoreOriginalSlot();
+                pendingRestoreSlot = false;
+            } else {
+                pendingRestoreTicksLeft--;
+            }
+        }
+    }
+
+    ;
+
+    private void startAnchorPvP() {
+        if (isActive)
+            return;
+        isActive = true;
+        originalSlot = mc.player.getInventory().selectedSlot;
+        hasPlacedThisCycle = false;
+        timer.reset();
+    }
+
+    private void stopAnchorPvP() {
+        if (!isActive)
+            return;
+        if (originalSlot != -1) {
+            mc.player.getInventory().selectedSlot = originalSlot;
+        }
+        isActive = false;
+        originalSlot = -1;
+        pendingRestoreSlot = false;
+        pendingRestoreTicksLeft = 0;
+    }
+
+    private void processAnchorPvP() {
+        if (mc.crosshairTarget instanceof BlockHitResult blockHit) {
+            BlockPos targetBlock = blockHit.getBlockPos();
+            var blockState = mc.world.getBlockState(targetBlock);
+
+            if (blockState.getBlock() == Blocks.RESPAWN_ANCHOR) {
+                int charges = blockState.get(RespawnAnchorBlock.CHARGES);
+
+                if (charges == 0) {
+                    if (swapToItem(Items.GLOWSTONE)) {
+                        hasPlacedThisCycle = true;
+                        if (mouseSimulation.getValue()) {
+                            MouseSimulation.mouseClick(GLFW.GLFW_MOUSE_BUTTON_RIGHT);
+                        } else {
+                            ((MinecraftClientAccessor) mc).invokeDoItemUse();
+                        }
+                    }
+                } else {
+                    if (swapToSword()) {
+                        if (mouseSimulation.getValue()) {
+                            MouseSimulation.mouseClick(GLFW.GLFW_MOUSE_BUTTON_RIGHT);
+                        } else {
+                            ((MinecraftClientAccessor) mc).invokeDoItemUse();
+                        }
+                        scheduleRestoreOriginalSlot();
+                    } else if (swapToItem(Items.TOTEM_OF_UNDYING)) {
+                        if (mouseSimulation.getValue()) {
+                            MouseSimulation.mouseClick(GLFW.GLFW_MOUSE_BUTTON_RIGHT);
+                        } else {
+                            ((MinecraftClientAccessor) mc).invokeDoItemUse();
+                        }
+                        scheduleRestoreOriginalSlot();
+                    }
+                    hasPlacedThisCycle = true;
+                }
+
+                return;
+            }
+
+            BlockPos placementPos = targetBlock.offset(blockHit.getSide());
+            if (isValidAnchorPosition(placementPos) && !hasPlacedThisCycle) {
+                if (swapToItem(Items.RESPAWN_ANCHOR)) {
+                    hasPlacedThisCycle = true;
+                    ((MinecraftClientAccessor) mc).invokeDoItemUse();
+                    MouseSimulation.mouseClick(GLFW.GLFW_MOUSE_BUTTON_RIGHT);
+                }
+            }
+        }
+    }
+
+    private boolean isValidAnchorPosition(BlockPos pos) {
+        if (mc.world == null || mc.player == null)
+            return false;
+
+        if (mc.player.getPos().distanceTo(Vec3d.ofCenter(pos)) > 4.5)
+            return false;
+
+        if (!mc.world.getBlockState(pos).isAir())
+            return false;
+
+        BlockPos playerPos = mc.player.getBlockPos();
+        return !pos.equals(playerPos) && !pos.equals(playerPos.up());
+    }
+
+    private boolean swapToItem(net.minecraft.item.Item item) {
+        for (int i = 0; i < 9; i++) {
+            if (i >= 0 && i < 9) {
+                var stack = mc.player.getInventory().getStack(i);
+                if (!stack.isEmpty() && stack.getItem() == item) {
+                    mc.player.getInventory().selectedSlot = i;
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean swapToSword() {
+        for (int i = 0; i < 9; i++) {
+            if (i >= 0 && i < 9) {
+                var stack = mc.player.getInventory().getStack(i);
+                if (!stack.isEmpty() && stack.getItem() instanceof SwordItem) {
+                    mc.player.getInventory().selectedSlot = i;
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void restoreOriginalSlot() {
+        if (originalSlot != -1) {
+            mc.player.getInventory().selectedSlot = originalSlot;
+        }
+    }
+
+    private void scheduleRestoreOriginalSlot() {
+        if (originalSlot != -1) {
+            pendingRestoreSlot = true;
+            pendingRestoreTicksLeft = restoreDelayTicks.getValueInt();
+        }
+    }
+
+    @Override
+    public void onEnable() {
+        keyPressed = false;
+        isActive = false;
+        originalSlot = -1;
+        hasPlacedThisCycle = false;
+        pendingRestoreSlot = false;
+        pendingRestoreTicksLeft = 0;
+        timer.reset();
+        super.onEnable();
+    }
+
+    @Override
+    public void onDisable() {
+        stopAnchorPvP();
+        super.onDisable();
+    }
+
+    @Override
+    public int getKey() {
+        return -1;
+    }
+}

--- a/src/main/java/com/volt/module/modules/combat/KeyCrystal.java
+++ b/src/main/java/com/volt/module/modules/combat/KeyCrystal.java
@@ -1,0 +1,197 @@
+package com.volt.module.modules.combat;
+
+import com.volt.event.impl.player.TickEvent;
+import com.volt.mixin.MinecraftClientAccessor;
+import com.volt.module.Category;
+import com.volt.module.Module;
+import com.volt.module.setting.BooleanSetting;
+import com.volt.module.setting.KeybindSetting;
+import com.volt.module.setting.NumberSetting;
+import com.volt.utils.keybinding.KeyUtils;
+import com.volt.utils.math.TimerUtil;
+import com.volt.utils.mc.InventoryUtil;
+import com.volt.utils.mc.MouseSimulation;
+
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.entity.decoration.EndCrystalEntity;
+import net.minecraft.item.Items;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import org.lwjgl.glfw.GLFW;
+
+public final class KeyCrystal extends Module {
+
+    private final KeybindSetting crystalKeybind = new KeybindSetting("Crystal Key", GLFW.GLFW_MOUSE_BUTTON_4, false);
+    private final NumberSetting delay = new NumberSetting("Delay (MS)", 1, 100, 10, 1);
+    private final BooleanSetting antiSuicide = new BooleanSetting("Anti Suicide", true);
+    private final BooleanSetting mouseSimulation = new BooleanSetting("Mouse Simulation", true);
+
+    private final TimerUtil timer = new TimerUtil();
+    private final TimerUtil attackTimer = new TimerUtil();
+
+    private boolean keyPressed = false;
+    private boolean isActive = false;
+    private int originalSlot = -1;
+    private boolean hasPlacedObsidian = false;
+
+    public KeyCrystal() {
+        super("Key Crystal", "Automatically places and explodes crystals and obsidian for PvP", -1, Category.COMBAT);
+        this.addSettings(crystalKeybind, delay, antiSuicide, mouseSimulation);
+        this.getSettings().removeIf(setting -> setting instanceof KeybindSetting && !setting.equals(crystalKeybind));
+    }
+
+    @EventHandler
+    private void onTickEvent(TickEvent event) {
+        if (isNull())
+            return;
+        if (mc.currentScreen != null)
+            return;
+        boolean currentKeyState = KeyUtils.isKeyPressed(crystalKeybind.getKeyCode());
+
+        if (currentKeyState && !keyPressed) {
+            startCrystalPvP();
+        } else if (!currentKeyState && keyPressed) {
+            stopCrystalPvP();
+        }
+
+        keyPressed = currentKeyState;
+
+        if (isActive && timer.hasElapsedTime(delay.getValueInt())) {
+            processCrystalPvP();
+            timer.reset();
+        }
+    }
+
+    ;
+
+    private void startCrystalPvP() {
+        if (isActive)
+            return;
+        isActive = true;
+        originalSlot = mc.player.getInventory().selectedSlot;
+        hasPlacedObsidian = false;
+        timer.reset();
+    }
+
+    private void stopCrystalPvP() {
+        if (!isActive)
+            return;
+        if (originalSlot != -1) {
+            mc.player.getInventory().selectedSlot = originalSlot;
+        }
+        isActive = false;
+        originalSlot = -1;
+        hasPlacedObsidian = false;
+    }
+
+    private void processCrystalPvP() {
+        if (antiSuicide.getValue() && !mc.player.isOnGround()) {
+            return;
+        }
+
+        if (mc.crosshairTarget instanceof EntityHitResult entityHit) {
+            if (entityHit.getEntity() instanceof EndCrystalEntity crystal) {
+
+                if (mc.player.getPos().distanceTo(crystal.getPos()) <= 6.0 && attackTimer.hasElapsedTime(150)) {
+                    if (mouseSimulation.getValue()) {
+                        MouseSimulation.mouseClick(GLFW.GLFW_MOUSE_BUTTON_LEFT);
+                    } else {
+                        ((MinecraftClientAccessor) mc).invokeDoAttack();
+                    }
+                    attackTimer.reset();
+                }
+                return;
+            }
+        }
+
+        if (mc.crosshairTarget instanceof BlockHitResult blockHit) {
+            BlockPos targetBlock = blockHit.getBlockPos();
+            BlockPos placementPos = targetBlock.offset(blockHit.getSide());
+
+            if (isObsidianOrBedrock(targetBlock) && isValidCrystalPosition(placementPos)) {
+                if (hasItemInHotbar(Items.END_CRYSTAL)) {
+                    InventoryUtil.swapToSlot(Items.END_CRYSTAL);
+                    if (mouseSimulation.getValue()) {
+                        MouseSimulation.mouseClick(GLFW.GLFW_MOUSE_BUTTON_RIGHT);
+                    } else {
+                        ((MinecraftClientAccessor) mc).invokeDoItemUse();
+                    }
+                }
+            } else if (isValidPosition(placementPos) && !hasPlacedObsidian) {
+                BlockPos below = placementPos.down();
+                if (!mc.world.getBlockState(below).isAir()) {
+                    if (hasItemInHotbar(Items.OBSIDIAN)) {
+                        InventoryUtil.swapToSlot(Items.OBSIDIAN);
+                        if (mouseSimulation.getValue()) {
+                            MouseSimulation.mouseClick(GLFW.GLFW_MOUSE_BUTTON_RIGHT);
+                        } else {
+                            ((MinecraftClientAccessor) mc).invokeDoItemUse();
+                        }
+                        hasPlacedObsidian = true;
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean hasItemInHotbar(net.minecraft.item.Item item) {
+        for (int i = 0; i < 9; i++) {
+            if (i >= 0 && i < 9) {
+                var stack = mc.player.getInventory().getStack(i);
+                if (!stack.isEmpty() && stack.getItem() == item) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isValidPosition(BlockPos pos) {
+        if (mc.world == null)
+            return false;
+        if (mc.player.getPos().distanceTo(Vec3d.ofCenter(pos)) > 4.5)
+            return false;
+        if (!mc.world.getBlockState(pos).isAir())
+            return false;
+
+        BlockPos playerPos = mc.player.getBlockPos();
+        return !pos.equals(playerPos) && !pos.equals(playerPos.up());
+    }
+
+    private boolean isObsidianOrBedrock(BlockPos pos) {
+        if (mc.world == null)
+            return false;
+        var block = mc.world.getBlockState(pos).getBlock();
+        return block == net.minecraft.block.Blocks.OBSIDIAN || block == net.minecraft.block.Blocks.BEDROCK;
+    }
+
+    private boolean isValidCrystalPosition(BlockPos pos) {
+        if (mc.world == null)
+            return false;
+        if (mc.player.getPos().distanceTo(Vec3d.ofCenter(pos)) > 4.5)
+            return false;
+
+        if (!mc.world.getBlockState(pos).isAir())
+            return false;
+
+        if (!mc.world.getBlockState(pos.up()).isAir())
+            return false;
+
+        BlockPos playerPos = mc.player.getBlockPos();
+        return !pos.equals(playerPos) && !pos.equals(playerPos.up()) && !pos.up().equals(playerPos)
+                && !pos.up().equals(playerPos.up());
+    }
+
+    @Override
+    public void onDisable() {
+        super.onDisable();
+        stopCrystalPvP();
+    }
+
+    @Override
+    public int getKey() {
+        return -1;
+    }
+}


### PR DESCRIPTION
Fixed KeyAnchor and KeyCrystal by adding a setting called MouseSimulation as before it was doing both invokeAttack and mouseClick which caused a double placement. Now it can only do one of the two.